### PR TITLE
fix invalid client index crash in VIP_Tag on client connect

### DIFF
--- a/addons/sourcemod/scripting/VIP_Tag.sp
+++ b/addons/sourcemod/scripting/VIP_Tag.sp
@@ -15,7 +15,7 @@ public Plugin myinfo =
 	name = "[VIP] Tag",
 	author = "R1KO, maxime1907",
 	description = "Gives a default VIP tag to VIPs",
-	version = "1.0.1",
+	version = "1.0.2",
 	url = ""
 };
 
@@ -35,7 +35,7 @@ public Action OnToggleItem(int client, const char[] sFeatureName, VIP_ToggleStat
 	return Plugin_Continue;
 }
 
-public void OnClientConnected(int client)
+public void OnClientPutInServer(int client)
 {
 	if (IsFakeClient(client))
 		return;


### PR DESCRIPTION
## Summary
- `OnClientConnected` fired `CS_GetClientClanTag` before the client
  entity existed, throwing `Client index N is not valid` (see server
  log below). Switched the hook to `OnClientPutInServer`, which only
  fires once the entity is created.

## Log before fix
L 08/16/2026 - 13:01:19: [SM] Exception reported: Client index 12 is not valid
L 08/16/2026 - 13:01:19: [SM] Blaming: vip/VIP_Tag.smx
L 08/16/2026 - 13:01:19: [SM]   [0] CS_GetClientClanTag
L 08/16/2026 - 13:01:19: [SM]   [1] Line 44, VIP_Tag.sp::OnClientConnected